### PR TITLE
v0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-bot",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A simple Discord bot written in Node.js that assigns roles when you react to messages.",
   "main": "index.js",
   "repository": "git@github.com:IAmFletcher/discord-bot.git",

--- a/src/WebSocketClient.js
+++ b/src/WebSocketClient.js
@@ -50,6 +50,9 @@ class WebSocketClient extends EventEmitter {
     console.log(`Gateway Closed: ${code} ${reason}`.trim());
 
     switch (code) {
+      case 1001:
+        this.connect();
+        break;
       case 4000: // unknown error
         this.connect();
         break;

--- a/src/WebSocketClient.js
+++ b/src/WebSocketClient.js
@@ -50,6 +50,8 @@ class WebSocketClient extends EventEmitter {
     console.log(`Gateway Closed: ${code} ${reason}`.trim());
 
     switch (code) {
+      case 1000:
+        break;
       case 1001:
         this.connect();
         break;
@@ -151,7 +153,7 @@ class WebSocketClient extends EventEmitter {
     }
 
     clearInterval(this._heartbeatInterval);
-    this._websocket.close();
+    this._websocket.close(1000);
   }
 
   sendPayload (op, data, sequence, type) {

--- a/src/WebSocketClient.js
+++ b/src/WebSocketClient.js
@@ -13,6 +13,8 @@ class WebSocketClient extends EventEmitter {
     this._sessionID = null;
     this._lastSequence = null;
 
+    this._identityTimestamp = null;
+
     autoBind(this);
   }
 
@@ -170,6 +172,13 @@ class WebSocketClient extends EventEmitter {
   }
 
   sendIdentityPayload () {
+    if (!this._identityTimestamp && (Date.now() - this._identityTimestamp) < 5000) {
+      setTimeout(this.sendIdentityPayload, 5000);
+      return;
+    }
+
+    this._identityTimestamp = Date.now();
+
     const data = {
       token: this._token,
       properties: {


### PR DESCRIPTION
This will hopefully prevent us from a) disconnecting permanently without reason b) missing any events between reconnections.

"Discord has a process for "resuming" (or reconnecting) a connection that allows the client to replay any lost events from the last sequence number they received in the exact same way they would receive them normally." - https://discordapp.com/developers/docs/topics/gateway#resuming

I've also added all of the Discord Close Codes, and a couple of the standard WebSocket Close Codes so that we can explictly reconnect/close connect depending on the code.

For Close Codes 4004 (authentication failed), 4008 (rate-limited) and 4011 (sharding required), I have decided to close the connection. This is because these are events that can only be fixed by updating the code or environment variables.

https://discordapp.com/developers/docs/topics/opcodes-and-status-codes
https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent